### PR TITLE
Fix alumni not showing after filter if currently on second page.

### DIFF
--- a/app/admin/alumni/page.tsx
+++ b/app/admin/alumni/page.tsx
@@ -429,6 +429,11 @@ export default function AlumniManagement(): ReactNode {
     return () => window.removeEventListener("resize", checkMobile)
   }, [])
 
+  // Reset to the first page on any filter change
+  useEffect(() => {
+    setCurrentPage(1); 
+  }, [searchQuery, selectedProgram, selectedCountry, selectedTags]);
+
   // Filter alumni
   const { filteredAlumni, uniqueCountries } = useMemo(() => {
     const countries = new Set<string>()


### PR DESCRIPTION
The pagination will break/not show any alumni if alumni is less than the items per page. This change will make the current page reset back to 1, on the 4 filter states.